### PR TITLE
Lower required ruby version

### DIFF
--- a/active_service.gemspec
+++ b/active_service.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.7.0'
+  spec.required_ruby_version = '>= 2.6.1'
 
   spec.add_runtime_dependency 'awesome_print'
 


### PR DESCRIPTION
Diminuindo `required_ruby_version` para atender a mais aplicações.