### PR TITLE
Expose additional error info when calling the safe version of the perform method

### DIFF
--- a/lib/active_service/base.rb
+++ b/lib/active_service/base.rb
@@ -16,7 +16,7 @@ module ActiveService
       def perform(*args)
         new(*args).perform
       rescue StandardError => e
-        Response.new(errors: e.message)
+        Response.new(errors: e.message, raised_exception: e)
       end
 
       def perform!(*args)

--- a/lib/active_service/base.rb
+++ b/lib/active_service/base.rb
@@ -16,7 +16,13 @@ module ActiveService
       def perform(*args)
         new(*args).perform
       rescue StandardError => e
-        Response.new(errors: e.message, raised_exception: e)
+        data = {
+          errors: e.message,
+          error_class: e.class.name
+        }
+        data[:error_backtrace] = e.backtrace if e.backtrace
+
+        Response.new(data)
       end
 
       def perform!(*args)

--- a/lib/active_service/response.rb
+++ b/lib/active_service/response.rb
@@ -13,6 +13,10 @@ module ActiveService
       errors.empty?
     end
 
+    def invalid?
+      !valid?
+    end
+
     def errors
       @errors ||= []
     end

--- a/lib/active_service/response.rb
+++ b/lib/active_service/response.rb
@@ -13,10 +13,6 @@ module ActiveService
       errors.empty?
     end
 
-    def invalid?
-      !valid?
-    end
-
     def errors
       @errors ||= []
     end

--- a/spec/active_service/base_spec.rb
+++ b/spec/active_service/base_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe ActiveService::Base do
     end
 
     context 'when exception is risen' do
-      before { allow(ActiveService::Base).to receive(:new).and_raise(StandardError) }
+      before { allow(ActiveService::Base).to receive(:new).and_raise(ArgumentError) }
 
       subject { described_class.perform }
 
@@ -59,6 +59,10 @@ RSpec.describe ActiveService::Base do
 
       it 'response is not valid' do
         expect(subject.valid?).to be false
+      end
+
+      it 'exposes the raised exception' do
+        expect(subject.raised_exception).to be_an(ArgumentError)
       end
     end
   end

--- a/spec/active_service/base_spec.rb
+++ b/spec/active_service/base_spec.rb
@@ -61,8 +61,12 @@ RSpec.describe ActiveService::Base do
         expect(subject.valid?).to be false
       end
 
-      it 'exposes the raised exception' do
-        expect(subject.raised_exception).to be_an(ArgumentError)
+      it "exposes the exception's class name" do
+        expect(subject.error_class).to eq 'ArgumentError'
+      end
+
+      it "exposes the exception's backtrace" do
+        expect(subject.error_backtrace).not_to be_empty
       end
     end
   end

--- a/spec/active_service/response_spec.rb
+++ b/spec/active_service/response_spec.rb
@@ -55,22 +55,4 @@ RSpec.describe ActiveService::Response do
       end
     end
   end
-
-  describe '#invalid?' do
-    context 'when success' do
-      subject { described_class.new(errors: 'message').invalid? }
-
-      it 'returns true when it is invalid?' do
-        is_expected.to be true
-      end
-    end
-
-    context 'when failure' do
-      subject { described_class.new.invalid? }
-
-      it 'returns false when it is not invalid?' do
-        is_expected.to be false
-      end
-    end
-  end
 end

--- a/spec/active_service/response_spec.rb
+++ b/spec/active_service/response_spec.rb
@@ -47,10 +47,28 @@ RSpec.describe ActiveService::Response do
       end
     end
 
-    context 'when faillure' do
+    context 'when failure' do
       subject { described_class.new(errors: 'message').valid? }
 
       it 'returns false when it is not valid?' do
+        is_expected.to be false
+      end
+    end
+  end
+
+  describe '#invalid?' do
+    context 'when success' do
+      subject { described_class.new(errors: 'message').invalid? }
+
+      it 'returns true when it is invalid?' do
+        is_expected.to be true
+      end
+    end
+
+    context 'when failure' do
+      subject { described_class.new.invalid? }
+
+      it 'returns false when it is not invalid?' do
         is_expected.to be false
       end
     end


### PR DESCRIPTION
- Retornar mais algumas informações sobre o erro que está sendo tratado durante a chamada do método `perform` sem bang.

**Gotchas:** Talvez seja necessário fazer algo do tipo pra pegar essas informações:
```ruby
ex = response.error_backtrace if response.respond_to?(:error_backtrace)
```